### PR TITLE
Remove tzinfo dependency

### DIFF
--- a/ical_importer.gemspec
+++ b/ical_importer.gemspec
@@ -17,7 +17,6 @@ Gem::Specification.new do |gem|
   gem.version       = IcalImporter::VERSION
 
   gem.add_dependency 'activesupport', ['> 3.0.0', '< 5.0']
-  gem.add_dependency 'tzinfo', '~> 0.3.29'
   gem.add_dependency 'icalendar', '~> 2.3.0'
   gem.add_dependency 'i18n', '~> 0.6'
 

--- a/lib/ical_importer.rb
+++ b/lib/ical_importer.rb
@@ -1,5 +1,4 @@
 require 'active_support/all'
-require 'tzinfo'
 require 'icalendar'
 
 require 'open-uri'


### PR DESCRIPTION
Remove the dependency on tzinfo since it locks it to an older version and doesn't appear to do anything with tzinfo itself.